### PR TITLE
Fix documentation inconsistencies and update architecture

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,12 +24,12 @@ PYTHONPATH=. uv run pytest tests/ --tb=short -q
 
 ## Docs
 
-- [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) -- Master conceptual model
-- [ROADMAP.md](../../ROADMAP.md) -- Phased plan
-- [TASKLIST.md](../../TASKLIST.md) -- Task breakdown
-- [docs/file-layout.md](../../docs/file-layout.md) -- Virtual file tree
-- [docs/workflows.md](../../docs/workflows.md) -- Workflow system
-- [docs/engagements-and-partnerships.md](../../docs/engagements-and-partnerships.md) -- Cross-org engagement and partnership model
-- [docs/sandbox-design.md](../../docs/sandbox-design.md) -- Docker sandbox architecture (future)
-- [docs/agent-dispatch.md](../../docs/agent-dispatch.md) -- Agent routing and team sessions
-- [docs/cognitive-architecture.md](../../docs/cognitive-architecture.md) -- Agent learning and memory (future)
+- [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md) -- Master conceptual model
+- [ROADMAP.md](../ROADMAP.md) -- Phased plan
+- [TASKLIST.md](../TASKLIST.md) -- Task breakdown
+- [docs/file-layout.md](../docs/file-layout.md) -- Virtual file tree
+- [docs/workflows.md](../docs/workflows.md) -- Workflow system
+- [docs/engagements-and-partnerships.md](../docs/engagements-and-partnerships.md) -- Cross-org engagement and partnership model
+- [docs/sandbox-design.md](../docs/sandbox-design.md) -- Docker sandbox architecture (future)
+- [docs/agent-dispatch.md](../docs/agent-dispatch.md) -- Agent routing and team sessions
+- [docs/cognitive-architecture.md](../docs/cognitive-architecture.md) -- Agent learning and memory (future)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ The following exists and works today:
 - **Agents**: Configurable agents with roles, personalities, models, tools, learning state
 - **Conversations**: Job, direct, task, engagement, admin, and activity conversations
 - **Agent runtime**: Claude Code CLI team sessions with bidirectional `stream-json` I/O; single-agent and multi-agent dispatch
-- **Engagements**: Basic workgroup-to-workgroup engagement model with lifecycle tracking and message syncing
+- **Engagements**: Basic workgroup-to-workgroup engagement model with lifecycle tracking and message syncing (Phase 1 migrates to org-level scoping)
 - **Jobs**: Job model with conversation, workflow state, and engagement linking
 - **Workspaces**: Basic git repo + worktree integration for workspace-enabled workgroups
 - **Virtual files**: JSON-based file store with topic-scoped isolation and file materialization

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,7 +47,7 @@ The top-level corporate structure. An organization has a name, a description, me
 
 - **Lead agent**: The org lead. Lives in the Administration workgroup (the designated operations workgroup). Can create projects, propose engagements to partnered organizations, onboard new workgroups, and coordinate cross-workgroup work.
 - **Members**: Humans invited to the organization. Membership grants visibility into the org's structure and the ability to interact with the org lead.
-- **Administration workgroup**: Every organization has one. It is the operations hub -- the org lead lives here and handles incoming engagements, project coordination, and organizational management.
+- **Administration workgroup** (the designated `operations_workgroup` in the data model): Every organization has one. It is the operations hub -- the org lead lives here and handles incoming engagements, project coordination, and organizational management.
 
 ### Workgroup
 
@@ -59,11 +59,13 @@ The lower-level organizational unit. A workgroup is like a department -- it has 
 
 ### Partnerships
 
+> **Note**: Partnerships are planned for Phase 1 of the [Roadmap](../ROADMAP.md) and are not yet implemented.
+
 Partnerships are directional trust links between organizations that enable cross-org collaboration.
 
 - **Directional**: A partnership from Org A to Org B means A can propose engagements to B. It does **not** mean B can propose engagements to A.
 - **Mutual**: Both directions must be established independently for mutual engagement capability.
-- **Lifecycle**: `proposed -> accepted -> active -> revoked`
+- **Lifecycle**: `proposed -> accepted -> active -> revoked` (with `declined` branch from `proposed`)
 - **No discovery required**: Once a partnership exists, either side (in the permitted direction) can propose engagements directly, without going through a public directory.
 
 ---
@@ -89,13 +91,14 @@ The atomic unit of work. A job happens within a single workgroup and is executed
 
 - **Agent team**: The workgroup's agents, coordinated by the workgroup lead.
 - **Workspace**: Each job gets its own isolated workspace (a worktree or copy branched from the workgroup's shared files). This is critical when multiple jobs within a project or engagement modify the same files -- isolation prevents clobbering. Completed jobs merge their changes back. Agents read/write through the agent team mechanism.
+- **Linkage**: Jobs carry an optional `engagement_id` and `project_id` to trace back to the engagement or project that spawned them. This enables the org lead to aggregate status and deliverables.
 - **Created by**: Workgroup lead (when decomposing a project), org lead (direct dispatch), or a human participant.
 - **Lifecycle**: `in_progress -> completed | cancelled`
 - **Conversation**: A chat where the agents discuss, plan, and execute. Humans can participate.
 
 ### Project
 
-Cross-workgroup collaboration within a single organization. A project coordinates work that spans multiple departments.
+Cross-workgroup collaboration within a single organization. A project coordinates work that spans multiple departments. Projects are planned for Phase 2 of the [Roadmap](../ROADMAP.md).
 
 - **Agent team**: The workgroup leads from each participating workgroup, coordinated by the org lead.
 - **Workspace**: A shared project workspace that all participating workgroup leads can access. Each workgroup lead can also create jobs within their own workgroup, using their workgroup's workspace.
@@ -107,6 +110,8 @@ Cross-workgroup collaboration within a single organization. A project coordinate
 
 Cross-organization work between two partnered organizations. An engagement is how organizations do business with each other.
 
+> **Note**: The current implementation scopes engagements to workgroups (`source_workgroup_id` / `target_workgroup_id`). Phase 1 of the [Roadmap](../ROADMAP.md) will migrate engagements to org-level scoping as described here.
+
 - **Agent team**: Org leads from both the source (requesting) and target (delivering) organizations.
 - **Workspace**: Contract-based visibility -- not all files are visible to the customer organization. The target org controls what the source org can see. See [Open Questions](#open-questions).
 - **Created by**: The source org's lead proposes, the target org's lead accepts.
@@ -115,6 +120,26 @@ Cross-organization work between two partnered organizations. An engagement is ho
 - **Internal engagements**: A human member of an org can create an engagement directly -- they describe what they need, and the org lead handles it the same way as external work.
 
 See [engagements-and-partnerships.md](engagements-and-partnerships.md) for the full engagement and partnership model.
+
+---
+
+## Conversation Kinds
+
+Every interaction in TeaParty happens through a conversation. Each conversation has a **kind** that determines its participants, dispatch behavior, and scope.
+
+| Kind | Purpose | Participants | Dispatch |
+|------|---------|-------------|----------|
+| `job` | Work execution within a workgroup | Workgroup agents + humans | Team session (multi-agent) or single agent |
+| `project` | Cross-workgroup coordination | Workgroup leads + org lead | Team session |
+| `engagement` | Cross-org negotiation and tracking | Org leads from both orgs | Single agent (org lead) |
+| `direct` | 1:1 conversation with an agent | One agent + one human | Single agent |
+| `task` | Persistent single-agent work session | One agent | Single agent with persistent session |
+| `admin` | Workgroup administration | Admin commands (no LLM selection) | Deterministic command handler |
+| `activity` | Activity log | Read-only | No auto-response |
+
+The three work-unit kinds (`job`, `project`, `engagement`) each have their own workspace and agent team as described in the [Work Hierarchy](#work-hierarchy) above. The remaining kinds (`direct`, `task`, `admin`, `activity`) are supporting conversation types that don't carry their own workspace.
+
+See [agent-dispatch.md](agent-dispatch.md) for the full routing table and dispatch mechanics.
 
 ---
 
@@ -235,6 +260,7 @@ These are design questions that need resolution as the system evolves:
 3. **Home agent capabilities**: How does the home agent discover available org templates? Is there a system-level registry?
 4. **Partnership revocation mid-engagement**: What happens to active engagements when a partnership is revoked? Grace period? Forced cancellation?
 5. **Project workspace isolation**: How do workgroup leads access both the project workspace and their own workgroup workspace simultaneously?
+6. **Legacy models**: The codebase contains `CrossGroupTask`, `CrossGroupTaskMessage`, and `AgentTask` models that predate the current engagement and job architecture. These should be evaluated for removal or migration as the engagement model is revised in Phase 1.
 
 ---
 

--- a/docs/agent-dispatch.md
+++ b/docs/agent-dispatch.md
@@ -123,6 +123,19 @@ An in-memory store (`_conversation_activity`) tracks what each agent is doing, e
 
 ---
 
+## Feedback Routing
+
+The feedback bubble-up model (see [ARCHITECTURE.md](ARCHITECTURE.md)) does not introduce a new conversation kind or dispatch path. Feedback requests flow through existing conversation kinds:
+
+1. A job agent posts a feedback request in the **job conversation**.
+2. The workgroup lead picks it up and escalates via the **project conversation** (or a direct message to the org lead).
+3. The org lead notifies the human via the **engagement conversation** or **direct message**.
+4. The human responds through the same channel, and the response routes back down.
+
+Each hop uses the existing dispatch routing for its conversation kind. No special feedback-specific routing is required.
+
+---
+
 ## Implementation
 
 | Component | File | Purpose |

--- a/docs/cognitive-architecture.md
+++ b/docs/cognitive-architecture.md
@@ -323,8 +323,8 @@ agent_runtime.run_agent_auto_responses()
 
 ### 5.3 Key Gaps
 
-1. **No memory retrieval pipeline**: `AgentMemory` exists but nothing reads from it during prompt construction. The injection point is `_build_prompt_body()` in `agent_definition.py:96-155` -- between the conversation context block and the guidelines block.
-2. **No reflection loop**: `AgentLearningEvent` exists but nothing triggers learning or writes to it. The hook point is `agent_runtime.py:473-483` -- immediately after `session.add(agent_message)` / `session.flush()`.
+1. **No memory retrieval pipeline**: `AgentMemory` exists but nothing reads from it during prompt construction. The injection point is `_build_prompt_body()` in `agent_definition.py` -- between the conversation context block and the guidelines block.
+2. **No reflection loop**: `AgentLearningEvent` exists but nothing triggers learning or writes to it. The hook point is in `agent_runtime.py` -- immediately after the agent message is persisted (`session.add(agent_message)` / `session.flush()`).
 3. **No memory decay/consolidation**: Memories accumulate without pruning
 4. **No cross-agent knowledge sharing**: Each agent's memory is siloed. `AgentMemory` lacks a `workgroup_id` column for cross-conversation retrieval.
 5. **No capability modeling**: Agents don't know what their teammates are good at
@@ -703,7 +703,7 @@ memory_consolidation_enabled: bool = False  # Phase 2
 Wire up the existing `AgentMemory` table:
 
 1. Add `_retrieve_memories()` to `prompt_builder.py` -- query `agent_memories` for the current agent, score by recency + relevance + importance
-2. Inject retrieved memories into the system prompt via `_build_prompt_body()` in `agent_definition.py:96-155` -- new section between conversation context and guidelines
+2. Inject retrieved memories into the system prompt via `_build_prompt_body()` in `agent_definition.py` -- new section between conversation context and guidelines
 3. Add `GET /api/agents/{id}/memories` endpoint for admin inspection
 4. Populate memories manually or via admin API to validate the retrieval pipeline before adding automatic learning
 
@@ -716,7 +716,7 @@ Wire up the existing `AgentMemory` table:
 Add asynchronous post-turn reflection:
 
 1. Create `teaparty_app/services/reflection.py` -- uses `llm_client.create_message()` with `resolve_model(purpose="cheap")` for reflection calls
-2. Hook into `agent_runtime.py:473-483` after `session.add(agent_message)` / `session.flush()` -- fire reflection in background thread, similar to `_process_auto_responses_in_background()` pattern at `agent_runtime.py:583-602`
+2. Hook into `agent_runtime.py` after the agent message is persisted -- fire reflection in background thread, similar to the `_process_auto_responses_in_background()` pattern
 3. Add schema migration for new `AgentMemory` columns (`workgroup_id`, `access_level`, `relevance_count`, `last_accessed_at`, `is_archived`)
 4. Add `POST /api/agents/{id}/reflect` admin endpoint for debugging
 

--- a/docs/engagements-and-partnerships.md
+++ b/docs/engagements-and-partnerships.md
@@ -43,6 +43,8 @@ A future enhancement may add an org directory for discovery, but the MVP relies 
 
 ## What Is an Engagement
 
+> **Note**: The current implementation scopes engagements to workgroups (`source_workgroup_id` / `target_workgroup_id`). Phase 1 of the [Roadmap](../ROADMAP.md) will migrate engagements to org-level scoping as described in this document.
+
 An engagement represents "someone asks an organization to do something." The source can be:
 
 - **External** -- A partnered organization proposes work. This is the cross-org collaboration path: Org A proposes an engagement to Org B (via their A->B partnership), they negotiate terms, and Org B delivers.
@@ -71,9 +73,9 @@ The Administration workgroup is not a special system concept -- it's a regular w
 ```
 proposed -> negotiating -> accepted -> in_progress -> completed -> reviewed
     |            |             |             |
-    +------------+-------------+-------------+---> cancelled
-                               |
-                            declined
+    +------------+-----+------+-------------+---> cancelled
+    |            |
+    +------------+---> declined
 ```
 
 1. **Proposed** -- A source (partnered org or internal human) creates the engagement with a title, scope, and requirements. This creates an engagement conversation visible to both parties. The org lead sees the message and responds.

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -12,6 +12,9 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the conceptual model this tree reflec
 ./
 +-- config.json                                          # System configuration
 |
++-- home/                                                # Per-user home level (Phase 1)
+|   +-- home.json                                        # Home agent config, user preferences
+|
 +-- tools/                                               # Tool registry (read-only)
 |   +-- file-ops/
 |   |   +-- toolkit.json                                 #   read_file, list_files, add_file, edit_file, ...
@@ -98,6 +101,7 @@ Each conversation is scoped to a subtree. Agents and users in that conversation 
 | Context                | Scope Path                                                 |
 |------------------------|------------------------------------------------------------|
 | System administration  | `.`                                                        |
+| Home (per-user)        | `./home`                                                   |
 | Organization admin     | `./organizations/<org>`                                    |
 | Engagement             | `./organizations/<org>/engagements/<engagement>`           |
 | Project                | `./organizations/<org>/projects/<project>`                 |
@@ -118,11 +122,11 @@ Each entity has a JSON configuration file at its root:
 | System       | `./config.json`                                                         | LLM models, API keys, agent behavior limits |
 | Organization | `./organizations/<org>/organization.json`                               | Name, description, operations workgroup, service description |
 | Partnership  | `./organizations/<org>/partnerships/<partnership>/partnership.json`      | Direction, status, partner org ID, established date |
-| Engagement   | `./organizations/<org>/engagements/<engagement>/engagement.json`        | Status, source/target org IDs, terms, engagement chain, linked project/job IDs |
+| Engagement   | `./organizations/<org>/engagements/<engagement>/engagement.json`        | Status, source/target IDs (currently workgroup-scoped, migrating to org-scoped in Phase 1), terms, engagement chain, linked project/job IDs |
 | Project      | `./organizations/<org>/projects/<project>/project.json`                 | Status, participating workgroup IDs, engagement_id |
 | Workgroup    | `./organizations/<org>/workgroups/<workgroup>/workgroup.json`           | Name, description, workspace config (image, preset, git_remote) |
 | Agent        | `./organizations/<org>/workgroups/<workgroup>/agents/<agent>/agent.json` | Model, personality, tool_names, thresholds |
-| Member       | `./organizations/<org>/members/<member>/member.json`                    | Org role (owner/admin/member), preferences |
+| Member       | `./organizations/<org>/members/<member>/member.json`                    | Org role (owner/admin/member), preferences. Note: the current data model tracks membership at the workgroup level; org-level membership is a Phase 1 target. |
 | Job          | `./organizations/<org>/workgroups/<workgroup>/jobs/<job>/job.json`      | Title, scope, status, engagement_id, project_id |
 
 ## Tools

--- a/docs/sandbox-design.md
+++ b/docs/sandbox-design.md
@@ -6,7 +6,7 @@ How TeaParty workgroups get real filesystems, git version control, containerized
 
 ## Problem
 
-TeaParty stores team files as JSON blobs in a SQLite column (`Team.files`). This works for collaborative documents, workflows, and configuration, but it cannot support real software engineering:
+TeaParty stores workgroup files as JSON blobs in a SQLite column (`Workgroup.files`). This works for collaborative documents, workflows, and configuration, but it cannot support real software engineering:
 
 - No git history, no branches, no merges, no diffs
 - No filesystem, so no `npm install`, no test runners, no build tools
@@ -17,7 +17,7 @@ TeaParty stores team files as JSON blobs in a SQLite column (`Team.files`). This
 ## Design Principles
 
 1. **Don't reimplement Claude Code.** Claude Code is a battle-tested coding agent with Bash execution, git operations, file editing, test running, and planning. TeaParty should orchestrate it, not duplicate it.
-2. **Git is the source of truth for code.** Team files (JSON blobs) remain for documents, workflows, and config (see [file-layout.md](file-layout.md)). Code lives in git repos on disk.
+2. **Git is the source of truth for code.** Workgroup files (JSON blobs) remain for documents, workflows, and config (see [file-layout.md](file-layout.md)). Code lives in git repos on disk.
 3. **Jobs map to branches.** Each job works on an isolated branch via git worktrees, enabling concurrent tasks without interference.
 4. **Containers are the sandbox boundary.** Claude Code runs inside containers with the job's files mounted. The container enforces resource limits and isolation. The host never executes untrusted commands.
 5. **TeaParty is the collaboration layer.** It manages who can access what, coordinates multi-agent workflows, tracks history and decisions, and presents a unified UI. The actual coding happens inside the sandbox.
@@ -57,21 +57,21 @@ TeaParty stores team files as JSON blobs in a SQLite column (`Team.files`). This
 
 ## Key Concepts
 
-### Team Repository
+### Workgroup Repository
 
-Every team has a **git repository** on the host filesystem. The repo is the team's codebase — it holds source code, configuration, and any artifacts that benefit from version history. The repo is created automatically when the team is created.
+Every workgroup has a **git repository** on the host filesystem. The repo is the workgroup's codebase — it holds source code, configuration, and any artifacts that benefit from version history. The repo is created automatically when the workgroup is created with workspace enabled.
 
 ```
-Team (DB)               Repository (disk)
-├── files (JSON)        ├── bare repo:  /data/repos/<team-id>/repo.git
-├── agents              ├── main worktree: /data/repos/<team-id>/main
+Workgroup (DB)          Repository (disk)
+├── files (JSON)        ├── bare repo:  /data/repos/<workgroup-id>/repo.git
+├── agents              ├── main worktree: /data/repos/<workgroup-id>/main
 ├── jobs ───────────────├── job worktrees:
-│   ├── job-1  ──────── │   ├── /data/repos/<team-id>/jobs/job-1  (branch: job/job-1)
-│   └── job-2  ──────── │   └── /data/repos/<team-id>/jobs/job-2  (branch: job/job-2)
+│   ├── job-1  ──────── │   ├── /data/repos/<workgroup-id>/jobs/job-1  (branch: job/job-1)
+│   └── job-2  ──────── │   └── /data/repos/<workgroup-id>/jobs/job-2  (branch: job/job-2)
 └── conversations       └── .teaparty/  (metadata, ignored by git)
 ```
 
-The JSON file store (`Team.files`) and the git repo coexist. The JSON store holds documents, workflows, and config — things that agents read as prompt context. The git repo holds code — things that get built, tested, and executed. The main branch is synced to `Team.files` so the file browser shows the current codebase state.
+The JSON file store (`Workgroup.files`) and the git repo coexist. The JSON store holds documents, workflows, and config — things that agents read as prompt context. The git repo holds code — things that get built, tested, and executed. The main branch is synced to `Workgroup.files` so the file browser shows the current codebase state.
 
 ### Branch-per-Job
 
@@ -79,7 +79,7 @@ Each job gets its own git worktree branching from `main`. This is the natural ma
 
 | TeaParty concept | Git concept | Why |
 |---|---|---|
-| Team | Repository | One codebase per team |
+| Workgroup | Repository | One codebase per workgroup |
 | Job | Branch + Worktree | Parallel tasks without interference |
 | Message history | Commit log | "Save progress" creates commits |
 | Job merge | PR / merge to main | Completed work flows back |
@@ -97,7 +97,7 @@ Worktree lifecycle:
 Each active job gets a **sandbox** — a Docker container that provides an isolated execution environment. The sandbox:
 - Has the job's worktree bind-mounted at `/workspace`
 - Has Claude Code CLI pre-installed
-- Has language runtimes and common tools (configurable per team via a `Dockerfile` or image reference in team config)
+- Has language runtimes and common tools (configurable per workgroup via a `Dockerfile` or image reference in workgroup config)
 - Runs with resource limits (CPU, memory, disk, network)
 - Has no access to the host network or other jobs (network-isolated by default)
 - Exposes a gRPC or HTTP sidecar for TeaParty to send commands and receive results
@@ -110,15 +110,15 @@ Sandboxes are **not** long-lived VMs. They are pooled and recycled:
 
 ## Data Model Changes
 
-### New fields on `Team`
+### New fields on `Workgroup`
 
 ```python
-class Team(SQLModel, table=True):
+class Workgroup(SQLModel, table=True):
     # ... existing fields ...
 
     # Repository (host-side paths)
-    repo_path: str = ""              # /data/repos/<team-id>/repo.git (bare)
-    repo_main_path: str = ""         # /data/repos/<team-id>/main (worktree)
+    repo_path: str = ""              # /data/repos/<workgroup-id>/repo.git (bare)
+    repo_main_path: str = ""         # /data/repos/<workgroup-id>/main (worktree)
 
     # Sandbox configuration
     sandbox_image: str = "teaparty/sandbox:default"  # Docker image for job containers
@@ -134,12 +134,12 @@ class Team(SQLModel, table=True):
 ```python
 class JobSandbox(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
-    team_id: str = Field(foreign_key="teams.id", index=True)
-    conversation_id: str = Field(foreign_key="conversation.id", unique=True, index=True)
+    workgroup_id: str = Field(foreign_key="workgroups.id", index=True)
+    conversation_id: str = Field(foreign_key="conversations.id", unique=True, index=True)
 
     # Git state
     branch_name: str             # job/<conversation-id>
-    worktree_path: str           # /data/repos/<team-id>/jobs/<conversation-id>
+    worktree_path: str           # /data/repos/<workgroup-id>/jobs/<conversation-id>
     base_commit: str = ""        # SHA of the commit this branch started from
     head_commit: str = ""        # current HEAD SHA
 
@@ -161,24 +161,24 @@ No model changes. Agents gain access to sandbox tools through their existing `to
 
 ### 1. `teaparty_app/services/repo_manager.py`
 
-Manages the lifecycle of team repositories and job worktrees on the host filesystem. This service never touches containers — it only manages git repos and worktrees.
+Manages the lifecycle of workgroup repositories and job worktrees on the host filesystem. This service never touches containers — it only manages git repos and worktrees.
 
 **Key functions:**
 
 ```python
-async def init_repo(session: Session, team: Team) -> None:
-    """Initialize a bare repo + main worktree for a team.
+async def init_repo(session: Session, workgroup: Workgroup) -> None:
+    """Initialize a bare repo + main worktree for a workgroup.
 
     Steps:
-    1. Create directory structure: /data/repos/<team-id>/
+    1. Create directory structure: /data/repos/<workgroup-id>/
     2. git init --bare repo.git
-    3. Create initial commit on main (with any existing team files synced to disk)
+    3. Create initial commit on main (with any existing workgroup files synced to disk)
     4. git worktree add main (checked out to main branch)
-    5. Update team.repo_path, team.repo_main_path, team.repo_status
+    5. Update workgroup.repo_path, workgroup.repo_main_path, workgroup.repo_status
     """
 
 async def create_job_worktree(
-    session: Session, team: Team, conversation: Conversation,
+    session: Session, workgroup: Workgroup, conversation: Conversation,
 ) -> JobSandbox:
     """Create a git worktree for a job.
 
@@ -198,7 +198,7 @@ async def remove_job_worktree(session: Session, job_sandbox: JobSandbox) -> None
     """
 
 async def merge_job(
-    session: Session, job_sandbox: JobSandbox, team: Team, user_id: str,
+    session: Session, job_sandbox: JobSandbox, workgroup: Workgroup, user_id: str,
 ) -> MergeResult:
     """Merge a job branch into main.
 
@@ -208,26 +208,26 @@ async def merge_job(
     3. git merge job/<conversation-id> --no-ff
     4. Handle conflicts (return conflict info if any — user resolves via UI or agent)
     5. Update job_sandbox status to 'merged'
-    6. Sync main worktree back to team.files (for the file browser UI)
+    6. Sync main worktree back to workgroup.files (for the file browser UI)
     """
 
-async def sync_main_to_files(session: Session, team: Team) -> None:
-    """Sync the main worktree's tracked files into team.files JSON.
+async def sync_main_to_files(session: Session, workgroup: Workgroup) -> None:
+    """Sync the main worktree's tracked files into workgroup.files JSON.
 
-    This keeps the TeaParty file browser working for coding teams.
+    This keeps the TeaParty file browser working for coding workgroups.
     Only syncs text files under a size threshold. Binary files get
     a placeholder entry with path and size metadata.
     """
 
-async def sync_files_to_main(session: Session, team: Team) -> None:
-    """Sync team.files JSON changes back to the main worktree.
+async def sync_files_to_main(session: Session, workgroup: Workgroup) -> None:
+    """Sync workgroup.files JSON changes back to the main worktree.
 
     Used when files are edited via the TeaParty UI file browser.
     Creates a commit: 'sync: updated via TeaParty UI'
     """
 
-async def destroy_repo(session: Session, team: Team) -> None:
-    """Remove all worktrees, the bare repo, and reset the team's repo fields.
+async def destroy_repo(session: Session, workgroup: Workgroup) -> None:
+    """Remove all worktrees, the bare repo, and reset the workgroup's repo fields.
 
     Requires owner role. This is destructive and irreversible.
     """
@@ -236,7 +236,7 @@ async def destroy_repo(session: Session, team: Team) -> None:
 **Git operations** are executed via `asyncio.create_subprocess_exec` calling the `git` binary directly. No Python git library — the git CLI is the most reliable and well-tested interface. All git commands run with `GIT_DIR` and `GIT_WORK_TREE` environment variables set explicitly to prevent any confusion about which repo is being operated on.
 
 **File sync strategy:**
-- **Main → JSON**: After each merge to main, scan tracked files and update `team.files`. Skip binary files (detected by `git diff --numstat` null markers or file extension heuristics). Cap synced file content at the existing 200KB limit. Store a summary entry for files that exceed the limit: `{"path": "large-file.bin", "content": "(binary, 4.2 MB)", "meta": {"binary": true, "size": 4404019}}`.
+- **Main → JSON**: After each merge to main, scan tracked files and update `workgroup.files`. Skip binary files (detected by `git diff --numstat` null markers or file extension heuristics). Cap synced file content at the existing 200KB limit. Store a summary entry for files that exceed the limit: `{"path": "large-file.bin", "content": "(binary, 4.2 MB)", "meta": {"binary": true, "size": 4404019}}`.
 - **JSON → Main**: When a user edits a file via the TeaParty file browser, write the change to the main worktree and auto-commit. This path is intentionally simple — the UI is a convenience, not the primary editing interface.
 - **Job worktree files are NOT synced to JSON during active work.** The job's worktree is the source of truth while the job is active. The TeaParty UI shows job files by reading the filesystem directly (via the sandbox or a read-only mount), not through the JSON column.
 
@@ -248,7 +248,7 @@ Manages Docker containers for sandboxed code execution.
 
 ```python
 async def ensure_sandbox(
-    session: Session, job_sandbox: JobSandbox, team: Team,
+    session: Session, job_sandbox: JobSandbox, workgroup: Workgroup,
 ) -> ContainerInfo:
     """Ensure a running container exists for this job.
 
@@ -333,7 +333,7 @@ RUN useradd -m -s /bin/bash sandbox
 USER sandbox
 ```
 
-Team owners can specify a custom `sandbox_image` in team config to get different language stacks (Rust, Go, Java, etc.) or pre-installed project dependencies.
+Workgroup owners can specify a custom `sandbox_image` in workgroup config to get different language stacks (Rust, Go, Java, etc.) or pre-installed project dependencies.
 
 **Resource limits** (applied via Docker container create):
 
@@ -348,7 +348,7 @@ The `connected` preset allows outbound network access for `npm install`, `pip in
 
 ### 3. `teaparty_app/services/sandbox_tools.py`
 
-Agent tools for interacting with the team's repository and job sandboxes. These replace the homegrown `claude_code` tool.
+Agent tools for interacting with the workgroup's repository and job sandboxes. These replace the homegrown `claude_code` tool.
 
 ```python
 SANDBOX_TOOL_SCHEMAS: list[dict] = [
@@ -509,13 +509,13 @@ The key tool is `sandbox_exec`. Its implementation:
 async def _tool_sandbox_exec(
     session: Session,
     job_sandbox: JobSandbox,
-    team: Team,
+    workgroup: Workgroup,
     agent: Agent,
     task: str,
     max_turns: int = 25,
 ) -> str:
     """Delegate a coding task to Claude Code CLI running in the sandbox."""
-    container = await sandbox_pool.ensure_sandbox(session, job_sandbox, team)
+    container = await sandbox_pool.ensure_sandbox(session, job_sandbox, workgroup)
 
     result = await sandbox_pool.invoke_claude_code(
         container_id=container.container_id,
@@ -532,7 +532,7 @@ async def _tool_sandbox_exec(
     return result.response_text
 ```
 
-This is the critical design decision: **TeaParty agents don't write code. They delegate to Claude Code.** A TeaParty agent decides *what* needs to be done (using conversation context, workflow state, team discussion), then hands the task to Claude Code which decides *how* to do it. This avoids duplicating Claude Code's planning, file editing, test running, and error recovery capabilities.
+This is the critical design decision: **TeaParty agents don't write code. They delegate to Claude Code.** A TeaParty agent decides *what* needs to be done (using conversation context, workflow state, workgroup discussion), then hands the task to Claude Code which decides *how* to do it. This avoids duplicating Claude Code's planning, file editing, test running, and error recovery capabilities.
 
 ### 4. `teaparty_app/services/repo_sync.py`
 
@@ -545,7 +545,7 @@ async def worktree_to_file_view(
     """Read the job's worktree files and return a virtual file list.
 
     Used by the UI to display job files without going through
-    the team.files JSON column. This reads the filesystem directly.
+    the workgroup.files JSON column. This reads the filesystem directly.
 
     Filters:
     - Only git-tracked files (not in .gitignore)
@@ -555,9 +555,9 @@ async def worktree_to_file_view(
     """
 
 async def export_main_to_files(
-    session: Session, team: Team,
+    session: Session, workgroup: Workgroup,
 ) -> None:
-    """Snapshot the main branch into team.files for the file browser.
+    """Snapshot the main branch into workgroup.files for the file browser.
 
     Called after:
     - merge_to_main completes
@@ -588,23 +588,23 @@ async def export_main_to_files(
 14. **Reviewer** posts review feedback
 15. After iteration, **User** says "Looks good, merge it"
 16. **Implementer** calls `merge_to_main`
-17. **TeaParty** merges the branch, syncs main to `team.files`, cleans up the worktree
+17. **TeaParty** merges the branch, syncs main to `workgroup.files`, cleans up the worktree
 
 ### Scenario: Importing an existing repository
 
-1. Owner creates a coding team
-2. In team config, sets `git_remote: "https://github.com/org/repo.git"`
+1. Owner creates a coding workgroup
+2. In workgroup config, sets `git_remote: "https://github.com/org/repo.git"`
 3. `repo_manager.init_repo()`:
    - `git clone --bare <remote> repo.git`
    - `git worktree add main` (checks out default branch)
-   - Syncs main to `team.files` for the file browser
+   - Syncs main to `workgroup.files` for the file browser
 4. Jobs now branch from the imported codebase
 
 ## Configuration
 
-### Team Config (`team.json`)
+### Workgroup Config (`workgroup.json`)
 
-Sandbox-related fields in team configuration:
+Sandbox-related fields in workgroup configuration:
 
 ```json
 {
@@ -632,13 +632,13 @@ class Settings(BaseSettings):
     # ... existing settings ...
 
     # Repository and sandbox settings
-    repo_root: str = "/data/repos"                     # Base directory for all team repos
+    repo_root: str = "/data/repos"                     # Base directory for all workgroup repos
     sandbox_docker_socket: str = "/var/run/docker.sock"
     sandbox_default_image: str = "teaparty/sandbox:default"
     sandbox_warm_pool_size: int = 2                    # Pre-warmed containers
     sandbox_max_containers: int = 10                   # Hard limit on concurrent containers
     sandbox_idle_timeout_minutes: int = 30             # Auto-stop idle containers
-    sandbox_max_jobs_per_team: int = 20                # Limit concurrent job branches
+    sandbox_max_jobs_per_workgroup: int = 20            # Limit concurrent job branches
 ```
 
 ## API Endpoints
@@ -646,42 +646,42 @@ class Settings(BaseSettings):
 ### Repository management
 
 ```
-POST   /api/teams/{team_id}/repo              Initialize repo for team
-GET    /api/teams/{team_id}/repo              Get repo status and info
-DELETE /api/teams/{team_id}/repo              Destroy repo (owner only)
-POST   /api/teams/{team_id}/repo/sync         Trigger manual file sync
+POST   /api/workgroups/{workgroup_id}/repo              Initialize repo for workgroup
+GET    /api/workgroups/{workgroup_id}/repo              Get repo status and info
+DELETE /api/workgroups/{workgroup_id}/repo              Destroy repo (owner only)
+POST   /api/workgroups/{workgroup_id}/repo/sync         Trigger manual file sync
 ```
 
 ### Job branch management
 
 ```
-GET    /api/teams/{team_id}/repo/jobs                   List all job branches
-GET    /api/teams/{team_id}/repo/jobs/{conv_id}         Get job branch status
-POST   /api/teams/{team_id}/repo/jobs/{conv_id}/merge   Merge job to main
-DELETE /api/teams/{team_id}/repo/jobs/{conv_id}         Remove job branch
+GET    /api/workgroups/{workgroup_id}/repo/jobs                   List all job branches
+GET    /api/workgroups/{workgroup_id}/repo/jobs/{conv_id}         Get job branch status
+POST   /api/workgroups/{workgroup_id}/repo/jobs/{conv_id}/merge   Merge job to main
+DELETE /api/workgroups/{workgroup_id}/repo/jobs/{conv_id}         Remove job branch
 ```
 
 ### File access (repo-backed)
 
 ```
-GET    /api/teams/{team_id}/repo/files?ref={branch|commit}     List files
-GET    /api/teams/{team_id}/repo/files/{path}?ref={branch}     Read file
-GET    /api/teams/{team_id}/repo/diff?base=main&head={branch}  Get diff
+GET    /api/workgroups/{workgroup_id}/repo/files?ref={branch|commit}     List files
+GET    /api/workgroups/{workgroup_id}/repo/files/{path}?ref={branch}     Read file
+GET    /api/workgroups/{workgroup_id}/repo/diff?base=main&head={branch}  Get diff
 ```
 
-These endpoints serve the UI's file browser when the team has a repo. The frontend detects `repo_status == "active"` and switches from the JSON-based file browser to the repo-backed one.
+These endpoints serve the UI's file browser when the workgroup has a repo. The frontend detects `repo_status == "active"` and switches from the JSON-based file browser to the repo-backed one.
 
 ### Sandbox status (for UI activity indicators)
 
 ```
-GET    /api/teams/{team_id}/sandboxes    List running sandbox containers with status
+GET    /api/workgroups/{workgroup_id}/sandboxes    List running sandbox containers with status
 ```
 
 ## Security Model
 
 ### Isolation boundaries
 
-1. **Container isolation**: Each job's sandbox is isolated from others. No shared filesystem beyond the specific worktree mount. No access to the TeaParty database or other teams' repos.
+1. **Container isolation**: Each job's sandbox is isolated from others. No shared filesystem beyond the specific worktree mount. No access to the TeaParty database or other workgroups' repos.
 
 2. **Git branch isolation**: Worktrees are git branches. One job cannot modify another job's files without going through a merge. `main` is only modified via merge operations.
 
@@ -690,7 +690,7 @@ GET    /api/teams/{team_id}/sandboxes    List running sandbox containers with st
    - **Editor**: Can use sandbox tools, commit to job branches, request merges.
    - **Member**: Read-only. Can view files and diffs but not execute commands or modify code.
 
-4. **API key isolation**: The `ANTHROPIC_API_KEY` is injected into sandbox containers as an environment variable. Each container gets the key associated with the team owner. Token usage is tracked and attributed to the requesting agent/user.
+4. **API key isolation**: The `ANTHROPIC_API_KEY` is injected into sandbox containers as an environment variable. Each container gets the key associated with the organization owner. Token usage is tracked and attributed to the requesting agent/user.
 
 5. **Network isolation**: Sandboxes default to no external network access. The `connected` preset enables outbound access for package managers. Inbound access is never allowed.
 
@@ -713,11 +713,11 @@ GET    /api/teams/{team_id}/sandboxes    List running sandbox containers with st
 
 ### Phase 1: Repository Manager (no containers)
 
-- Add `repo_*` fields to Team and `JobSandbox` model
+- Add `repo_*` fields to Workgroup and `JobSandbox` model
 - Implement `repo_manager.py` with git operations
 - Add repo API endpoints
 - Hook into job creation/deletion lifecycle
-- File sync between main worktree and `team.files`
+- File sync between main worktree and `workgroup.files`
 - **Agents operate via direct git/file commands on the host** (no container isolation yet)
 - This phase is useful even without containers — it adds git history and branching
 
@@ -732,7 +732,7 @@ GET    /api/teams/{team_id}/sandboxes    List running sandbox containers with st
 ### Phase 3: Claude Code Integration
 
 - Replace the homegrown `claude_code.py` tool with `sandbox_exec`
-- Update the `coding` team template to use sandbox tools
+- Update the `coding` workgroup template to use sandbox tools
 - Add `sandbox_exec`, `git_status`, `git_commit`, `git_diff` to agent tool sets
 - Update agent system prompts to explain the repo + sandbox model
 
@@ -747,7 +747,7 @@ GET    /api/teams/{team_id}/sandboxes    List running sandbox containers with st
 ### Phase 5: Advanced Features
 
 - Remote git push/pull (sync with GitHub, GitLab)
-- Custom Dockerfiles per team
+- Custom Dockerfiles per workgroup
 - Persistent container volumes for `node_modules`, `.venv`, etc. (cache mounts)
 - Container snapshots for reproducible environments
 - Multi-file diff review workflow
@@ -761,7 +761,7 @@ GET    /api/teams/{team_id}/sandboxes    List running sandbox containers with st
 
 3. **Conflict resolution**: When merging job→main, conflicts can arise. Options: (a) reject the merge and show conflicts in the UI, (b) let an agent resolve conflicts via `sandbox_exec`, (c) create a conflict-resolution job. Start with (a), add (b) later.
 
-4. **File browser source of truth**: For teams with repos, should the file browser read from `team.files` (cached, potentially stale) or from the filesystem (live, requires API call)? Recommendation: read from filesystem for the active job's worktree, from `team.files` for the main branch overview.
+4. **File browser source of truth**: For teams with repos, should the file browser read from `workgroup.files` (cached, potentially stale) or from the filesystem (live, requires API call)? Recommendation: read from filesystem for the active job's worktree, from `workgroup.files` for the main branch overview.
 
 5. **Cost attribution**: Claude Code CLI usage inside sandboxes consumes API tokens. How to attribute this to specific users/agents for budget tracking? The container's API key usage can be tracked via Anthropic's API usage endpoints, or by parsing Claude Code's `--output-format json` output which includes token counts.
 
@@ -790,7 +790,7 @@ teaparty_app/
 │   └── repo_sync.py           # Bidirectional file sync (filesystem ↔ JSON)
 ├── routers/
 │   └── repo.py                # REST API endpoints for repo + sandbox management
-├── models.py                  # + JobSandbox model, Team repo fields
+├── models.py                  # + JobSandbox model, Workgroup repo fields
 └── config.py                  # + repo_*, sandbox_* settings
 
 docker/


### PR DESCRIPTION
## Summary

Comprehensive documentation updates addressing inconsistencies, terminology fixes, and conceptual clarifications across the architecture.

## Changes

### Documentation Fixes
- **CLAUDE.md**: Corrected relative paths in documentation links (from `../../docs/` to `../docs/`)
- **ARCHITECTURE.md**: 
  - Added clarifications on Administration workgroup as `operations_workgroup`
  - Added notes on unimplemented features (Partnerships, Projects)
  - Added new "Conversation Kinds" section documenting all conversation types and dispatch behavior
  - Added engagement linkage documentation (job references to engagement/project)
  - Clarified legacy models needing evaluation

- **sandbox-design.md**: Systematically updated terminology from "Team" to "Workgroup" throughout (~100+ occurrences)
- **agent-dispatch.md**: Added Feedback Routing section explaining bubble-up model
- **engagements-and-partnerships.md**: Updated engagement lifecycle diagram and added Phase 1 migration notes
- **file-layout.md**: 
  - Added home level structure
  - Clarified current vs. planned membership scoping
  - Updated engagement configuration documentation
- **cognitive-architecture.md**: Removed file-specific line number references (line numbers change with edits)
- **ROADMAP.md**: Clarified engagement model migration to org-level scoping in Phase 1

### Content Additions
- Conversation kinds table mapping kinds to participants and dispatch methods
- Phase markers for unimplemented features (Partnerships, Projects)
- Current vs. planned implementation notes
- Clarification on workgroup-scoped vs. org-scoped engagement architecture
