### PR TITLE
Fix silent learning extraction failures (#115)

### DIFF
--- a/projects/POC/orchestrator/learnings.py
+++ b/projects/POC/orchestrator/learnings.py
@@ -22,7 +22,6 @@ memory stores. Implements all 10 scopes of the promote_learnings.sh pipeline:
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
 
 
@@ -44,7 +43,6 @@ async def extract_learnings(
         scripts_dir, infra_dir,
         scope='observations',
         output=os.path.join(project_dir, 'proxy.md'),
-        task=task,
     )
 
     # Extract escalation → proxy-tasks/
@@ -52,7 +50,6 @@ async def extract_learnings(
         scripts_dir, infra_dir,
         scope='escalation',
         output=os.path.join(project_dir, 'proxy-tasks'),
-        task=task,
     )
 
     # Extract intent-alignment → tasks/
@@ -60,7 +57,6 @@ async def extract_learnings(
         scripts_dir, infra_dir,
         scope='intent-alignment',
         output=os.path.join(project_dir, 'tasks'),
-        task=task,
     )
 
     # ── Rollup scopes ─────────────────────────────────────────────────────────
@@ -102,40 +98,50 @@ async def extract_learnings(
 def _run_summarize(
     scripts_dir: str,
     infra_dir: str,
+    *,
     scope: str,
     output: str,
-    task: str,
 ) -> None:
-    """Run summarize_session.py for a specific scope."""
-    script = os.path.join(scripts_dir, 'summarize_session.py')
-    if not os.path.exists(script):
+    """Call summarize_session.summarize() directly for an intent-stream scope.
+
+    Previous implementation shelled out via subprocess with CLI args that
+    didn't match summarize_session.py's argparser (--task doesn't exist,
+    multiple --stream flags but CLI expects one). Errors were swallowed by
+    a bare ``except Exception: pass``.
+
+    Now calls the Python function directly, picking the right stream file
+    for the scope.
+    """
+    # Pick the correct stream for the scope
+    # observations and escalation use the intent stream;
+    # intent-alignment uses the exec stream
+    if scope in ('observations', 'escalation'):
+        stream_name = '.intent-stream.jsonl'
+    else:
+        stream_name = '.exec-stream.jsonl'
+
+    stream_path = os.path.join(infra_dir, stream_name)
+    if not os.path.exists(stream_path) or os.path.getsize(stream_path) == 0:
         return
 
-    # Find stream files
-    streams = []
-    for name in ('.intent-stream.jsonl', '.plan-stream.jsonl', '.exec-stream.jsonl'):
-        path = os.path.join(infra_dir, name)
-        if os.path.exists(path) and os.path.getsize(path) > 0:
-            streams.append(path)
-
-    if not streams:
-        return
-
-    args = [
-        'python3', script,
-        '--scope', scope,
-        '--output', output,
-        '--task', task,
-    ]
-    for s in streams:
-        args.extend(['--stream', s])
-
+    added_to_path = False
     try:
-        subprocess.run(
-            args, capture_output=True, text=True, timeout=60,
+        if scripts_dir and scripts_dir not in sys.path:
+            sys.path.insert(0, scripts_dir)
+            added_to_path = True
+        from summarize_session import summarize
+        summarize(stream_path, output, [], scope)
+    except Exception as exc:
+        print(
+            f'[learnings] {scope} extraction failed: {exc}',
+            file=sys.stderr,
         )
-    except Exception:
-        pass
+    finally:
+        if added_to_path:
+            try:
+                sys.path.remove(scripts_dir)
+            except ValueError:
+                pass
 
 
 # ── Rollup scope helpers ───────────────────────────────────────────────────────
@@ -149,9 +155,11 @@ def _call_promote(scripts_dir: str, scope: str, **kwargs) -> None:
             added_to_path = True
         from summarize_session import promote
         promote(scope, **kwargs)
-    except Exception:
-        # Swallow all exceptions to keep orchestration robust, as before.
-        pass
+    except Exception as exc:
+        print(
+            f'[learnings] promote {scope} failed: {exc}',
+            file=sys.stderr,
+        )
     finally:
         if added_to_path:
             try:

--- a/projects/POC/orchestrator/tests/test_learnings.py
+++ b/projects/POC/orchestrator/tests/test_learnings.py
@@ -852,5 +852,103 @@ class TestExtractLearningsIntegration(unittest.TestCase):
         self.assertEqual(mock_promote.call_count, 7, "Expected 7 _call_promote calls")
 
 
+# ── _run_summarize() direct-call behavior (issue #115 fixes) ─────────────────
+
+class TestRunSummarize(unittest.TestCase):
+    """Verify _run_summarize calls summarize() directly with correct args."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.scripts_dir = os.path.join(self.tmpdir, 'scripts')
+        self.infra_dir = os.path.join(self.tmpdir, 'infra')
+        os.makedirs(self.scripts_dir)
+        os.makedirs(self.infra_dir)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _make_stream(self, name: str) -> str:
+        path = os.path.join(self.infra_dir, name)
+        Path(path).write_text('{"type":"test"}\n')
+        return path
+
+    def test_observations_uses_intent_stream(self):
+        """observations scope reads .intent-stream.jsonl, not exec stream."""
+        self._make_stream('.intent-stream.jsonl')
+        self._make_stream('.exec-stream.jsonl')
+
+        calls = []
+
+        def fake_summarize(stream_path, output_path, ctx, scope, **kw):
+            calls.append({'stream': stream_path, 'scope': scope})
+            return 0
+
+        with patch.dict('sys.modules', {'summarize_session': type(sys)('summarize_session')}):
+            import sys as _sys
+            _sys.modules['summarize_session'].summarize = fake_summarize
+            from projects.POC.orchestrator.learnings import _run_summarize
+            _run_summarize(self.scripts_dir, self.infra_dir,
+                           scope='observations', output='/tmp/out.md')
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn('.intent-stream.jsonl', calls[0]['stream'])
+
+    def test_intent_alignment_uses_exec_stream(self):
+        """intent-alignment scope reads .exec-stream.jsonl."""
+        self._make_stream('.exec-stream.jsonl')
+
+        calls = []
+
+        def fake_summarize(stream_path, output_path, ctx, scope, **kw):
+            calls.append({'stream': stream_path, 'scope': scope})
+            return 0
+
+        with patch.dict('sys.modules', {'summarize_session': type(sys)('summarize_session')}):
+            sys.modules['summarize_session'].summarize = fake_summarize
+            from projects.POC.orchestrator.learnings import _run_summarize
+            _run_summarize(self.scripts_dir, self.infra_dir,
+                           scope='intent-alignment', output='/tmp/out.md')
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn('.exec-stream.jsonl', calls[0]['stream'])
+
+    def test_skips_when_stream_missing(self):
+        """Returns silently when the required stream file doesn't exist."""
+        # No stream files created
+        calls = []
+
+        def fake_summarize(stream_path, output_path, ctx, scope, **kw):
+            calls.append(scope)
+            return 0
+
+        with patch.dict('sys.modules', {'summarize_session': type(sys)('summarize_session')}):
+            sys.modules['summarize_session'].summarize = fake_summarize
+            from projects.POC.orchestrator.learnings import _run_summarize
+            _run_summarize(self.scripts_dir, self.infra_dir,
+                           scope='observations', output='/tmp/out.md')
+
+        self.assertEqual(len(calls), 0)
+
+    def test_logs_errors_instead_of_swallowing(self):
+        """Errors are printed to stderr, not silently swallowed."""
+        self._make_stream('.intent-stream.jsonl')
+
+        def boom(*a, **kw):
+            raise RuntimeError('test explosion')
+
+        with patch.dict('sys.modules', {'summarize_session': type(sys)('summarize_session')}):
+            sys.modules['summarize_session'].summarize = boom
+            from projects.POC.orchestrator.learnings import _run_summarize
+
+            import io
+            captured = io.StringIO()
+            with patch('sys.stderr', captured):
+                _run_summarize(self.scripts_dir, self.infra_dir,
+                               scope='observations', output='/tmp/out.md')
+
+            self.assertIn('test explosion', captured.getvalue())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- `_run_summarize()` was shelling out to `summarize_session.py` via subprocess with CLI args that don't match its argparser (`--task` doesn't exist, multiple `--stream` flags but CLI expects one). A bare `except Exception: pass` swallowed all errors silently — this is why no learnings were ever produced.
- Now calls `summarize()` directly as a Python function (matching the pattern already used by the 7 promote helpers), picks the correct stream file per scope (intent stream for observations/escalation, exec stream for intent-alignment), and logs errors to stderr instead of swallowing them.
- Removed unused `subprocess` import.

## Test plan
- [x] All 47 existing tests pass unchanged
- [x] 4 new tests in `TestRunSummarize` verify:
  - observations scope reads `.intent-stream.jsonl`
  - intent-alignment scope reads `.exec-stream.jsonl`
  - Missing stream files are skipped gracefully
  - Errors are logged to stderr, not swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)