### PR TITLE
Issue #317: replace prompt() with modal dialogs in project onboarding UI

### DIFF
--- a/docs/proposals/ui-redesign/mockup/index.html
+++ b/docs/proposals/ui-redesign/mockup/index.html
@@ -82,40 +82,74 @@
 <script>
 function openPage(url) { window.open(url, '_blank'); }
 
-// Project onboarding: pick a folder and register it via /api/projects/add or /api/projects/create
-async function pickAndCreateProject() {
-  var path = prompt('Enter path for new project directory:');
-  if (!path) return;
-  var name = prompt('Project name:', path.split('/').filter(Boolean).pop() || 'new-project');
-  if (!name) return;
-  try {
-    var resp = await fetch('/api/projects/create', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({name: name, path: path}),
-    });
-    var data = await resp.json();
-    if (!resp.ok) { alert('Error: ' + (data.error || resp.status)); return; }
-    loadData();
-  } catch(e) { alert('Error: ' + e.message); }
+// Show a modal dialog for project onboarding (add or create).
+// title: dialog heading; endpoint: '/api/projects/add' or '/api/projects/create'
+function showProjectModal(title, endpoint) {
+  var overlay = document.createElement('div');
+  overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;' +
+    'background:rgba(0,0,0,0.7);z-index:1000;display:flex;align-items:center;justify-content:center;';
+  overlay.innerHTML =
+    '<div style="background:var(--surface);border:1px solid var(--border);border-radius:6px;' +
+      'padding:20px;width:380px;font-family:inherit;">' +
+      '<div style="font-size:13px;font-weight:600;color:var(--green);margin-bottom:16px;">' + title + '</div>' +
+      '<label style="display:block;font-size:10px;color:var(--text-dim);margin-bottom:4px;">Directory path</label>' +
+      '<input id="om-path" type="text" placeholder="/path/to/project" ' +
+        'style="width:100%;background:var(--bg);border:1px solid var(--border);color:var(--text);' +
+        'padding:6px 8px;font-size:11px;font-family:inherit;border-radius:3px;margin-bottom:12px;box-sizing:border-box;" />' +
+      '<label style="display:block;font-size:10px;color:var(--text-dim);margin-bottom:4px;">Project name</label>' +
+      '<input id="om-name" type="text" placeholder="my-project" ' +
+        'style="width:100%;background:var(--bg);border:1px solid var(--border);color:var(--text);' +
+        'padding:6px 8px;font-size:11px;font-family:inherit;border-radius:3px;margin-bottom:6px;box-sizing:border-box;" />' +
+      '<div id="om-error" style="font-size:10px;color:var(--red);min-height:16px;margin-bottom:10px;"></div>' +
+      '<div style="display:flex;gap:8px;justify-content:flex-end;">' +
+        '<button id="om-cancel" style="background:transparent;border:1px solid var(--border);' +
+          'color:var(--text-dim);padding:6px 14px;border-radius:3px;font-size:11px;font-family:inherit;cursor:pointer;">' +
+          'Cancel</button>' +
+        '<button id="om-confirm" style="background:var(--accent2);border:none;color:var(--text);' +
+          'padding:6px 14px;border-radius:3px;font-size:11px;font-family:inherit;cursor:pointer;">' +
+          'Confirm</button>' +
+      '</div>' +
+    '</div>';
+  document.body.appendChild(overlay);
+
+  var pathInput = document.getElementById('om-path');
+  var nameInput = document.getElementById('om-name');
+  var errorEl = document.getElementById('om-error');
+
+  // Auto-fill name from the last path segment as the user types.
+  pathInput.addEventListener('input', function() {
+    var parts = pathInput.value.split('/').filter(Boolean);
+    if (parts.length) nameInput.value = parts[parts.length - 1];
+  });
+
+  function close() { document.body.removeChild(overlay); }
+
+  document.getElementById('om-cancel').addEventListener('click', close);
+
+  document.getElementById('om-confirm').addEventListener('click', async function() {
+    var path = pathInput.value.trim();
+    var name = nameInput.value.trim();
+    errorEl.textContent = '';
+    if (!path) { errorEl.textContent = 'Directory path is required.'; return; }
+    if (!name) { errorEl.textContent = 'Project name is required.'; return; }
+    try {
+      var resp = await fetch(endpoint, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({name: name, path: path}),
+      });
+      var data = await resp.json();
+      if (!resp.ok) { errorEl.textContent = data.error || 'Request failed (' + resp.status + ').'; return; }
+      close();
+      loadData();
+    } catch(e) { errorEl.textContent = e.message; }
+  });
+
+  pathInput.focus();
 }
 
-async function pickAndAddProject() {
-  var path = prompt('Enter path to existing project directory:');
-  if (!path) return;
-  var name = prompt('Project name:', path.split('/').filter(Boolean).pop() || 'my-project');
-  if (!name) return;
-  try {
-    var resp = await fetch('/api/projects/add', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({name: name, path: path}),
-    });
-    var data = await resp.json();
-    if (!resp.ok) { alert('Error: ' + (data.error || resp.status)); return; }
-    loadData();
-  } catch(e) { alert('Error: ' + e.message); }
-}
+function pickAndCreateProject() { showProjectModal('New Project', '/api/projects/create'); }
+function pickAndAddProject() { showProjectModal('Add Project', '/api/projects/add'); }
 
 // Standard CfA phase sequence for workflow bar rendering.
 // Bars: INTENT, PLAN, WORK, DONE. Gates (circles): INTENT_ASSERT, PLAN_ASSERT, WORK_ASSERT.

--- a/tests/test_issue_317.py
+++ b/tests/test_issue_317.py
@@ -1,0 +1,125 @@
+"""Tests for issue #317: Replace prompt() with modal dialogs in project onboarding UI.
+
+Acceptance criteria:
+1. No prompt() calls remain in the onboarding functions
+2. Modal dialog function exists (showProjectModal)
+3. Modal has labeled inputs for path and name (om-path, om-name)
+4. Inline error display element exists (om-error)
+5. No alert() calls in the onboarding path
+6. Both /api/projects/create and /api/projects/add are still called on confirm
+"""
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+
+class TestOnboardingModalUI(unittest.TestCase):
+    """index.html onboarding must use a modal dialog, not prompt() or alert()."""
+
+    def _get_index_source(self) -> str:
+        for candidate in [
+            _REPO_ROOT / 'bridge' / 'static' / 'index.html',
+            _REPO_ROOT / 'docs' / 'proposals' / 'ui-redesign' / 'mockup' / 'index.html',
+        ]:
+            if candidate.exists():
+                return candidate.read_text()
+        self.fail('index.html not found in bridge/static/ or docs mockup')
+
+    def test_no_prompt_calls(self):
+        """index.html must not use prompt() for onboarding input."""
+        source = self._get_index_source()
+        self.assertNotIn(
+            'prompt(',
+            source,
+            'index.html must not use prompt() — replace with a modal dialog',
+        )
+
+    def test_modal_function_exists(self):
+        """index.html must define showProjectModal for onboarding."""
+        source = self._get_index_source()
+        self.assertIn(
+            'showProjectModal',
+            source,
+            'index.html must define showProjectModal() for the onboarding dialog',
+        )
+
+    def test_modal_path_input_exists(self):
+        """Modal must contain a path input (om-path)."""
+        source = self._get_index_source()
+        self.assertIn(
+            'om-path',
+            source,
+            'Modal must have a path input element with id om-path',
+        )
+
+    def test_modal_name_input_exists(self):
+        """Modal must contain a name input (om-name)."""
+        source = self._get_index_source()
+        self.assertIn(
+            'om-name',
+            source,
+            'Modal must have a project name input element with id om-name',
+        )
+
+    def test_modal_inline_error_display_exists(self):
+        """Modal must display errors inline (om-error), not via alert()."""
+        source = self._get_index_source()
+        self.assertIn(
+            'om-error',
+            source,
+            'Modal must have an inline error element with id om-error',
+        )
+
+    def test_no_alert_in_onboarding(self):
+        """index.html must not call alert() in the onboarding path."""
+        source = self._get_index_source()
+        # Extract the section around pickAndCreateProject/pickAndAddProject
+        # to avoid false positives from unrelated code.
+        start = source.find('pickAndCreateProject')
+        end = source.rfind('pickAndAddProject') + 200
+        if start == -1 or end < start:
+            self.fail('pickAndCreateProject/pickAndAddProject not found in index.html')
+        onboarding_section = source[start:end]
+        self.assertNotIn(
+            'alert(',
+            onboarding_section,
+            'Onboarding functions must not use alert() — show errors inline in the modal',
+        )
+
+    def test_create_calls_projects_create_endpoint(self):
+        """pickAndCreateProject must POST to /api/projects/create."""
+        source = self._get_index_source()
+        self.assertIn(
+            '/api/projects/create',
+            source,
+            'index.html must call /api/projects/create when creating a new project',
+        )
+
+    def test_add_calls_projects_add_endpoint(self):
+        """pickAndAddProject must POST to /api/projects/add."""
+        source = self._get_index_source()
+        self.assertIn(
+            '/api/projects/add',
+            source,
+            'index.html must call /api/projects/add when adding an existing project',
+        )
+
+    def test_modal_calls_load_data_on_success(self):
+        """Modal must call loadData() after a successful API response."""
+        source = self._get_index_source()
+        # Find the modal function and check loadData() is called within it.
+        start = source.find('showProjectModal')
+        end = source.find('pickAndCreateProject', start + 1)
+        if start == -1:
+            self.fail('showProjectModal not found in index.html')
+        modal_fn = source[start:end] if end > start else source[start:start + 2000]
+        self.assertIn(
+            'loadData()',
+            modal_fn,
+            'showProjectModal must call loadData() after a successful API response',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Removes `prompt()` and `alert()` from `pickAndCreateProject` and `pickAndAddProject`
- Introduces `showProjectModal(title, endpoint)`: a styled modal with labeled path/name text inputs, inline error display, and Cancel/Confirm buttons
- Auto-fills the project name from the last path segment as the user types the directory path
- On success, closes the modal and calls `loadData()` to refresh the project list; on error, displays the message inline (no `alert()`)

Note: `showDirectoryPicker` (File System Access API) was considered but can't be used here — it returns a `FileSystemDirectoryHandle`, not a filesystem path the bridge server can consume. Text input is the correct approach.

## Test plan

- [ ] 9 new spec tests in `tests/test_issue_317.py` — all pass
- [ ] `test_no_prompt_calls` — `prompt(` absent from source
- [ ] `test_modal_function_exists` — `showProjectModal` defined
- [ ] `test_modal_path_input_exists` — `om-path` input present
- [ ] `test_modal_name_input_exists` — `om-name` input present
- [ ] `test_modal_inline_error_display_exists` — `om-error` element present
- [ ] `test_no_alert_in_onboarding` — no `alert(` in onboarding functions
- [ ] `test_create_calls_projects_create_endpoint` — `/api/projects/create` call present
- [ ] `test_add_calls_projects_add_endpoint` — `/api/projects/add` call present
- [ ] `test_modal_calls_load_data_on_success` — `loadData()` called after success

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)