### PR TITLE
Fix CI: resolve 4 test failures left over from #320

### DIFF
--- a/scripts/summarize_session.py
+++ b/scripts/summarize_session.py
@@ -92,13 +92,22 @@ def _wrap_learnings_with_frontmatter(
     Includes session_id and session_task from environment when available,
     so entries are structurally tied to their originating session.
     """
+    import sys as _sys
+    from pathlib import Path as _Path
+    _scripts_dir = str(_Path(__file__).parent)
+    _added_to_path = _scripts_dir not in _sys.path
+    if _added_to_path:
+        _sys.path.insert(0, _scripts_dir)
     try:
-        import sys as _sys
-        from pathlib import Path as _Path
-        _sys.path.insert(0, str(_Path(__file__).parent))
         from memory_entry import make_entry, serialize_entry
     except ImportError:
         return learnings  # graceful degradation
+    finally:
+        if _added_to_path:
+            try:
+                _sys.path.remove(_scripts_dir)
+            except ValueError:
+                pass
 
     importance = _SCOPE_IMPORTANCE.get(scope, 0.5)
     effective_domain = domain or _SCOPE_DOMAIN.get(scope, "team")
@@ -1265,9 +1274,19 @@ def _try_compact(path: str) -> None:
     try:
         from pathlib import Path as _Path
         import sys as _sys
-        _sys.path.insert(0, str(_Path(__file__).parent))
-        from compact_memory import compact_file
-        compact_file(path)
+        scripts_dir = str(_Path(__file__).parent)
+        _added = scripts_dir not in _sys.path
+        if _added:
+            _sys.path.insert(0, scripts_dir)
+        try:
+            from compact_memory import compact_file
+            compact_file(path)
+        finally:
+            if _added:
+                try:
+                    _sys.path.remove(scripts_dir)
+                except ValueError:
+                    pass
     except Exception:
         pass
 

--- a/tests/test_approval_gate.py
+++ b/tests/test_approval_gate.py
@@ -23,7 +23,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
 from scripts.approval_gate import (
     COLD_START_THRESHOLD,
     EXPLORE_RATE,

--- a/tests/test_issue_181.py
+++ b/tests/test_issue_181.py
@@ -104,7 +104,7 @@ class TestEventBusPublishWarning(unittest.TestCase):
         bus.subscribe(bad_subscriber)
 
         with self.assertLogs('orchestrator.events', level='WARNING') as cm:
-            asyncio.get_event_loop().run_until_complete(bus.publish(event))
+            asyncio.run(bus.publish(event))
 
         self.assertTrue(
             any('WARNING' in line for line in cm.output),
@@ -130,7 +130,7 @@ class TestEventBusPublishWarning(unittest.TestCase):
 
         # We expect a warning log; use assertLogs to capture it
         with self.assertLogs('orchestrator.events', level='WARNING'):
-            asyncio.get_event_loop().run_until_complete(bus.publish(event))
+            asyncio.run(bus.publish(event))
 
         self.assertEqual(len(called), 1, "Good subscriber should still be called")
 

--- a/tests/test_issue_308.py
+++ b/tests/test_issue_308.py
@@ -1197,7 +1197,7 @@ class TestRestConfigProject(unittest.TestCase):
                     "workgroups: []\n")
         # Create a project with project.yaml
         proj_dir = os.path.join(self._tmp, 'myproject')
-        teaparty_proj_dir = os.path.join(proj_dir, '.teaparty')
+        teaparty_proj_dir = os.path.join(proj_dir, '.teaparty.local')
         os.makedirs(teaparty_proj_dir)
         with open(os.path.join(teaparty_proj_dir, 'project.yaml'), 'w') as f:
             f.write("name: My Project\ndescription: A test project\nlead: proj-lead\n"

--- a/tests/test_learnings.py
+++ b/tests/test_learnings.py
@@ -870,10 +870,14 @@ class TestCompactFileWiring(unittest.TestCase):
         self.scripts_dir = str(
             Path(__file__).parent.parent / 'scripts'
         )
+        self._sys_path_before = sys.path[:]
 
     def tearDown(self):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
+        # Restore sys.path exactly to the state before this test ran.
+        # _load_summarize_session adds scripts_dir; this undoes only what was added.
+        sys.path[:] = self._sys_path_before
 
     def _load_summarize_session(self):
         """Get the summarize_session module that _call_promote will use.
@@ -1051,11 +1055,14 @@ class TestCallPromoteImportPath(unittest.TestCase):
                     )
 
     def test_call_promote_cleans_up_sys_path(self):
-        """After _call_promote returns, scripts_dir is removed from sys.path."""
+        """_call_promote must not leave scripts_dir permanently added to sys.path."""
         from orchestrator.learnings import _call_promote
+        before_count = sys.path.count(self.scripts_dir)
         with patch('scripts.summarize_session.summarize', return_value=0):
             _call_promote(self.scripts_dir, 'team', session_dir='', project_dir='', output_dir='')
-        self.assertNotIn(self.scripts_dir, sys.path)
+        after_count = sys.path.count(self.scripts_dir)
+        self.assertEqual(after_count, before_count,
+                         "_call_promote must not net-add scripts_dir to sys.path")
 
 
 # ── _run_summarize() direct-call behavior (issue #115 fixes) ─────────────────


### PR DESCRIPTION
## Summary
- `test_issue_181`: replace deprecated `asyncio.get_event_loop().run_until_complete()` with `asyncio.run()` (Python 3.12 raises `RuntimeError` when no current loop)
- `test_issue_308::TestRestConfigProject`: setUp created project fixture at `.teaparty/` but `load_project_team()` reads from `.teaparty.local/`
- `test_learnings::TestCallPromoteImportPath::test_call_promote_cleans_up_sys_path`: two sources of `sys.path` contamination — `test_approval_gate.py` had a redundant `scripts/` insert (dotted imports work without it), and `TestCompactFileWiring._load_summarize_session` added `scripts_dir` without cleanup; fixed with snapshot/restore in `tearDown` and count-invariance assertion
- `scripts/summarize_session.py`: `_wrap_learnings_with_frontmatter` and `_try_compact` permanently leaked `scripts/` into `sys.path`; converted to track-and-cleanup pattern consistent with `_call_promote`

## Test plan
- [ ] `uv run pytest tests/ --tb=short -q` passes (3201 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)