### PR TITLE
Fix #344: replace --setting-sources user with --bare

### DIFF
--- a/docs/detailed-design/agent-runtime.md
+++ b/docs/detailed-design/agent-runtime.md
@@ -43,7 +43,7 @@ Each phase invokes an **AgentRunner** (which wraps `ClaudeRunner`) to run a Clau
 claude -p \
   --output-format stream-json \
   --verbose \
-  --setting-sources user \
+  --bare \
   --permission-mode acceptEdits \
   --agents '<team-definition-JSON>' \
   --agent intent-lead \

--- a/orchestrator/claude_runner.py
+++ b/orchestrator/claude_runner.py
@@ -192,7 +192,7 @@ class ClaudeRunner:
             'claude', '-p',
             '--output-format', 'stream-json',
             '--verbose',
-            '--setting-sources', 'user',
+            '--bare',
         ]
         args.extend(['--permission-mode', self.permission_mode])
         if self.agents_file:

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -189,6 +189,24 @@ class TestPermissionModeAlwaysPresent(unittest.TestCase):
         self.assertEqual(args[idx + 1], 'dontAsk')
 
 
+class TestBareFlag(unittest.TestCase):
+    """_build_args must pass --bare for skill scope suppression (Issue #344)."""
+
+    def _get_args(self) -> list[str]:
+        runner = _make_runner()
+        return runner._build_args(None)
+
+    def test_bare_flag_present(self):
+        """--bare must appear in the CLI args to suppress skill auto-discovery."""
+        args = self._get_args()
+        self.assertIn('--bare', args)
+
+    def test_setting_sources_not_present(self):
+        """--setting-sources must not appear — it controls settings files, not skills."""
+        args = self._get_args()
+        self.assertNotIn('--setting-sources', args)
+
+
 class TestClaudeResultDataclass(unittest.TestCase):
     """ClaudeResult dataclass — default values and had_errors property."""
 

--- a/tests/test_integration_dispatch_spawn.py
+++ b/tests/test_integration_dispatch_spawn.py
@@ -140,7 +140,7 @@ class TestProjectLeadSpawnsTeammateViaTask(unittest.TestCase):
             'claude', '-p',
             '--output-format', 'stream-json',
             '--verbose',
-            '--setting-sources', 'user',
+            '--bare',
             '--agents', agents_json,
             '--agent', 'project-lead',
             '--permission-mode', 'acceptEdits',


### PR DESCRIPTION
## Summary

- Replaces `--setting-sources user` with `--bare` in `orchestrator/claude_runner.py:_build_args()` — the correct flag for suppressing skill auto-discovery
- Updates the CLI example in `docs/detailed-design/agent-runtime.md` to match
- Adds `TestBareFlag` tests verifying `--bare` is present and `--setting-sources` is absent
- Updates `tests/test_integration_dispatch_spawn.py` manual arg list to match

`--setting-sources` controls which settings files are loaded; it does not affect skill directory scanning. `--bare` suppresses auto-discovery of hooks, skills, plugins, MCP servers, auto memory, and CLAUDE.md so spawned agents see exactly the composed set. The proposal (`invocation-model.md`) already specified `--bare`; this fix makes the code and detailed-design doc consistent with it.

## Test plan

- [x] `TestBareFlag.test_bare_flag_present` — `--bare` in `_build_args()` output
- [x] `TestBareFlag.test_setting_sources_not_present` — `--setting-sources` absent
- [x] Full suite: 3710 passed, 0 failed

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)